### PR TITLE
Added unit tests for #22

### DIFF
--- a/test/test_files/component_constructor_init.ts
+++ b/test/test_files/component_constructor_init.ts
@@ -1,0 +1,22 @@
+import ExampleController from './exported_controller';
+
+const template = require('./example-template.html');
+
+export class ExampleComponent {
+    public controller: any;
+    public bindings: any;
+    public template: string;
+
+    constructor() {
+        this.controller = ExampleController;
+        this.template = template;
+        this.bindings = {
+            data: '<'
+        };
+    }
+}
+
+angular
+    .module('app', [])
+    .component('exampleComponent', new ExampleComponent())
+

--- a/test/test_files/component_required_template.ts
+++ b/test/test_files/component_required_template.ts
@@ -1,0 +1,11 @@
+let template = require('./template.html');
+
+function controller() {}
+
+angular.module('moduleName').component('componentName', {
+    template: template,
+    bindings: {
+        data: '<'
+    },
+    controller: controller
+});

--- a/test/test_files/exported_controller.ts
+++ b/test/test_files/exported_controller.ts
@@ -1,0 +1,3 @@
+export default class ExportedController {
+
+}

--- a/test/utils/component.test.ts
+++ b/test/utils/component.test.ts
@@ -79,6 +79,24 @@ describe('Give Component class', () => {
 
 			assertComponents(components);
 		});
+
+		it('with component_required_template.ts file then a properly parsed component is returned', async () => {
+			const { path, sourceFile } = getSourceFile('component_required_template.ts');
+
+			const components = await Component.parse({ path, sourceFile }, []);
+
+			const expectedTemplatePath = getTestFilePath('template.html');
+			assert.equal(components[0].template.path, expectedTemplatePath);
+		});
+
+		it('with component_constructor_init.ts file then a properly parsed component is returned', async () => {
+			const { path, sourceFile } = getSourceFile('component_constructor_init.ts');
+
+			const components = await Component.parse({ path, sourceFile }, []);
+
+			const expectedTemplatePath = getTestFilePath('example-template.html');
+			assert.equal(components[0].template.path, expectedTemplatePath);
+		});
 	});
 });
 


### PR DESCRIPTION
These are 2 cases I was working on. I hope it makes a bit more sense now 😄 

In the second example (constructor_init) it should also resolve the controller. But I don't think the component unit tests cover controller discovery. Please tell me if I'm wrong. Also, I've added a dummy controller (exported_controller.ts) for this test. It's probably unneeded if unit tests can't pick it up - and I can delete it?