### PR TITLE
Handle component definition on routes in ui-router

### DIFF
--- a/src/utils/templateParser.ts
+++ b/src/utils/templateParser.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import * as path from 'path';
+import { kebabCase } from 'lodash';
 import { TypescriptParser } from './typescriptParser';
 import { IComponentTemplate } from './component/component';
 import { RelativePath } from './htmlTemplate/relativePath';
@@ -8,7 +9,21 @@ import { ConfigParser } from './configParser';
 export class TemplateParser {
 	public createTemplate = (config: ConfigParser, parser: TypescriptParser) => {
 		return this.createTemplateFromUrl(config.get('templateUrl'), parser)
-				|| this.createFromInlineTemplate(config.get('template'), parser);
+			|| this.createFromInlineTemplate(config.get('template'), parser)
+			|| this.createFromComponentDef(config.get('component'), parser);
+	}
+
+	private createFromComponentDef = (node: ts.Expression, parser: TypescriptParser): IComponentTemplate => {
+		if (!node) {
+			return undefined;
+		}
+
+		const literal = node as ts.LiteralExpression;
+		const kebabName = kebabCase(literal.text);
+		// In the future, handle bindings for usage
+		literal.text = `<${kebabName}></${kebabName}>`;
+
+		return this.createFromInlineTemplate(literal, parser);
 	}
 
 	private createFromInlineTemplate = (node: ts.Expression, parser: TypescriptParser): IComponentTemplate => {

--- a/test/test_files/routes/route.component_template.ts
+++ b/test/test_files/routes/route.component_template.ts
@@ -1,0 +1,8 @@
+angular
+  .module('app')
+  .config(function ($stateProvider) {
+    $stateProvider
+      .state('example_route', {
+		component: 'componentName',
+      });
+  });

--- a/test/utils/route.test.ts
+++ b/test/utils/route.test.ts
@@ -17,6 +17,17 @@ describe('Given Route class', () => {
 			assert.equal(route.template.path, sourceFile.path);
 		});
 
+		it('on route with component and no template then template is set correctly', async () => {
+			const sourceFile = getRouteSourceFile('route.component_template.ts');
+
+			const [route] = await Route.parse(sourceFile, []);
+
+			assert.equal(route.path, sourceFile.path);
+			assert.equal(route.name, 'example_route');
+			assert.equal(route.template.body, '<component-name></component-name>');
+			assert.equal(route.template.path, sourceFile.path);
+		});
+
 		it('on route with external template then template is set correctly', async () => {
 			mockRoot('testRoot');
 			const sourceFile = getRouteSourceFile('route.external_template.ts');


### PR DESCRIPTION
Handle component definition on routes (supported by ui-router for AngularJS)

ui-router supports the following in a route definition:

```js
.state('userlist', {
  url: '/users',
  component: 'users', // The component's name
  resolve: {
    users: function(UserService) {
      return UserService.list();
    }
  }
});
```

See: https://ui-router.github.io/guide/ng1/route-to-component#update-the-state-definition

This patch adds the ability to transform the component name to a template like so:

```component: 'componentName'``` becomes ```<component-name></component-name>```