### PR TITLE
Add support for template definition inside of view configuration (ui-router)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import { MemberDefinitionProvider } from './providers/memberDefinitionProvider';
 import { MemberReferencesProvider } from './providers/memberReferencesProvider';
 import { CodeActionProvider } from './providers/codeActionsProvider';
 
-import { IComponentTemplate, Component } from './utils/component/component';
+import { IComponentTemplate, Component, IComponentBase } from './utils/component/component';
 import { ComponentsCache } from './utils/component/componentsCache';
 import { HtmlTemplateInfoCache } from './utils/htmlTemplate/htmlTemplateInfoCache';
 import { RoutesCache } from './utils/route/routesCache';
@@ -256,5 +256,14 @@ export class Extension {
 		});
 	}
 
-	private getTemplatesWithBody = (source: Array<{ template: IComponentTemplate }>) => source.filter(c => c.template && c.template.body).map(c => c.template);
+	private getTemplatesWithBody = (source: Array<{ template: IComponentTemplate, views?: IComponentBase[] }>) =>
+		_.flatMap(source, (c) => {
+			if (c.template && c.template.body) {
+				return c.template;
+			}
+
+			if (c.views && c.views.length > 0) {
+				return c.views.filter(v => v.template && v.template.body).map(v => v.template);
+			}
+		})
 }

--- a/src/utils/component/componentParser.ts
+++ b/src/utils/component/componentParser.ts
@@ -171,7 +171,11 @@ export class ComponentParser {
 		const bindingsObj = config.get('bindings');
 		if (bindingsObj) {
 			const bindingsProps = bindingsObj as ts.ObjectLiteralExpression;
-			component.bindings.push(...bindingsProps.properties.map(b => new ComponentBinding(b as ts.PropertyAssignment, parser)));
+			// AngularJS allows either `bindings: true` or `bindings: { ... }` syntax
+			// Ignore the former here because it does not contribute to autocompletion
+			if (bindingsProps.properties) {
+				component.bindings.push(...bindingsProps.properties.map(b => new ComponentBinding(b as ts.PropertyAssignment, parser)));
+			}
 		}
 
 		component.template = this.templateParser.createTemplate(config, parser);

--- a/src/utils/configParser.ts
+++ b/src/utils/configParser.ts
@@ -34,6 +34,8 @@ export class ConfigParser {
 
 	public get = (name: string) => this.properties[name];
 
+	public entries = () => Object.entries(this.properties);
+
 	private isClass(config: ts.ObjectLiteralExpression | ts.ClassDeclaration): config is ts.ClassDeclaration {
 		return (config as ts.ClassDeclaration).members !== undefined;
 	}

--- a/src/utils/route/route.ts
+++ b/src/utils/route/route.ts
@@ -10,6 +10,8 @@ export class Route implements IComponentBase {
 	public name: string;
 	public pos: ts.LineAndCharacter;
 
+	public views: IComponentBase[];
+
 	public path: string;
 	public template: IComponentTemplate;
 	public controller: Controller;

--- a/src/utils/templateParser.ts
+++ b/src/utils/templateParser.ts
@@ -13,7 +13,7 @@ export class TemplateParser {
 			|| this.createFromComponentDef(config.get('component'), parser);
 	}
 
-	private createFromComponentDef = (node: ts.Expression, parser: TypescriptParser): IComponentTemplate => {
+	public createFromComponentDef = (node: ts.Expression, parser: TypescriptParser): IComponentTemplate => {
 		if (!node) {
 			return undefined;
 		}

--- a/src/utils/typescriptParser.ts
+++ b/src/utils/typescriptParser.ts
@@ -247,10 +247,12 @@ export class TypescriptParser {
 				result = this.getDeclarationFromExportAssignment(statement, name);
 			}
 
-			if (result.varDeclaration) {
+			if (result && result.varDeclaration) {
 				return result.varDeclaration;
 			}
-			defaultFallback = result.defaultDeclaration;
+			if (result && result.defaultDeclaration) {
+				defaultFallback = result.defaultDeclaration;
+			}
 
 			// TODO: The following valid ES Module declarations are not supported yet.  They require a full tree traversal.
 			// export default function () { } // also class, function*

--- a/src/utils/typescriptParser.ts
+++ b/src/utils/typescriptParser.ts
@@ -3,6 +3,11 @@ import { SourceFile, ISourceFile } from './sourceFile';
 import * as path from 'path';
 import * as fs from 'fs';
 
+export interface IDeclarationOrDefault {
+	varDeclaration?: ts.VariableDeclaration;
+	defaultDeclaration?: ts.VariableDeclaration;
+}
+
 export function isTsKind<T extends ts.Node = ts.Node>(node: ts.Node, syntaxKind: ts.SyntaxKind): node is T {
 	return node.kind === syntaxKind;
 }
@@ -190,8 +195,44 @@ export class TypescriptParser {
 		}
 	}
 
-	public getExportedVariable = (name: string): ts.VariableDeclaration => {
+	private getDeclarationFromVariableStatement = (statement: ts.VariableStatement, name: string): IDeclarationOrDefault => {
+		// export let name1, name2, …, nameN; // also var, const
+		// export let name1 = 1, name2 = 2, 3, nameN; // also var, const
 		let varDeclaration: ts.VariableDeclaration;
+		varDeclaration = statement.declarationList.declarations.find(x => (x.name as ts.Identifier).text === name);
+		if (varDeclaration && statement.modifiers && statement.modifiers.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword)) {
+			return { varDeclaration };
+		}
+	}
+
+	private getDeclarationFromExportDeclarationStatement = (statement: ts.ExportDeclaration, name: string): IDeclarationOrDefault => {
+		const exp = statement.exportClause.elements.find(x => (x.name as ts.Identifier).text === name);
+		if (exp && exp.propertyName && exp.name.text !== 'default') {
+			// export { variable1 as name1, variable2 as name2, nameN };
+			return { varDeclaration: this.getVariableDefinition(exp.propertyName) };
+		} else if (exp && exp.propertyName && exp.name.text === 'default') {
+			// export { name1 as default };
+			return { defaultDeclaration: this.getVariableDefinition(exp.propertyName) };
+		} else if (exp) {
+			// export { name1, name2, …, nameN };
+			return { varDeclaration: this.getVariableDefinition(exp.name) };
+		}
+	}
+
+	private getDeclarationFromExportAssignment = (statement: ts.ExportAssignment, name: string): IDeclarationOrDefault => {
+		const exp = statement.expression;
+		if (isTsKind<ts.Identifier>(exp, ts.SyntaxKind.Identifier)) {
+			// export default identifier;
+			if (exp.text === name) {
+				return { varDeclaration: this.getVariableDefinition(exp) };
+			} else {
+				return { defaultDeclaration: this.getVariableDefinition(exp) };
+			}
+		}
+	}
+
+	public getExportedVariable = (name: string): ts.VariableDeclaration => {
+		let result: IDeclarationOrDefault;
 		let defaultFallback: ts.VariableDeclaration;
 		let i = 0;
 
@@ -199,36 +240,17 @@ export class TypescriptParser {
 			const statement = this.sourceFile.statements[i];
 
 			if (isTsKind<ts.VariableStatement>(statement, ts.SyntaxKind.VariableStatement)) {
-				// export let name1, name2, …, nameN; // also var, const
-				// export let name1 = 1, name2 = 2, 3, nameN; // also var, const
-
-				varDeclaration = statement.declarationList.declarations.find(x => (x.name as ts.Identifier).text === name);
-				if (varDeclaration && statement.modifiers && statement.modifiers.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword)) {
-					return varDeclaration;
-				}
+				result = this.getDeclarationFromVariableStatement(statement, name);
 			} else if (isTsKind<ts.ExportDeclaration>(statement, ts.SyntaxKind.ExportDeclaration)) {
-				const exp = statement.exportClause.elements.find(x => (x.name as ts.Identifier).text === name);
-				if (exp && exp.propertyName && exp.name.text !== 'default') {
-					// export { variable1 as name1, variable2 as name2, nameN };
-					return this.getVariableDefinition(exp.propertyName);
-				} else if (exp && exp.propertyName && exp.name.text === 'default') {
-					// export { name1 as default };
-					defaultFallback = this.getVariableDefinition(exp.propertyName);
-				} else if (exp) {
-					// export { name1, name2, …, nameN };
-					return this.getVariableDefinition(exp.name);
-				}
+				result = this.getDeclarationFromExportDeclarationStatement(statement, name);
 			} else if (isTsKind<ts.ExportAssignment>(statement, ts.SyntaxKind.ExportAssignment)) {
-				const exp = statement.expression;
-				if (isTsKind<ts.Identifier>(exp, ts.SyntaxKind.Identifier)) {
-					// export default identifier;
-					if (exp.text === name) {
-						return this.getVariableDefinition(exp);
-					} else {
-						defaultFallback = this.getVariableDefinition(exp);
-					}
-				}
+				result = this.getDeclarationFromExportAssignment(statement, name);
 			}
+
+			if (result.varDeclaration) {
+				return result.varDeclaration;
+			}
+			defaultFallback = result.defaultDeclaration;
 
 			// TODO: The following valid ES Module declarations are not supported yet.  They require a full tree traversal.
 			// export default function () { } // also class, function*

--- a/test/test_files/routes/route.views_template.ts
+++ b/test/test_files/routes/route.views_template.ts
@@ -1,0 +1,19 @@
+angular
+  .module('app')
+  .config(function ($stateProvider) {
+    $stateProvider
+      .state('example_route', {
+		  views: {
+			  'inline-component': 'InlineComponent',
+			  'inline-template': {
+				  template: 'inline-template'
+			  },
+			  'template-url': {
+				  templateUrl: './subdir/template.html',
+			  },
+			  'template-component': {
+				  component: 'TemplateComponent'
+			  }
+		  }
+      });
+  });

--- a/test/utils/htmlTemplateInfoCache.test.ts
+++ b/test/utils/htmlTemplateInfoCache.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
+import * as _ from 'lodash';
 import proxyquire = require('proxyquire');
 import { IHtmlTemplateInfoResults } from '../../src/utils/htmlTemplate/types';
+import { Route } from '../../src/utils/route/route';
 
 class MockedRelativePath {
 	public relative: string;
@@ -36,6 +38,62 @@ describe('Given HtmlTemplateInfoCache class', () => {
 
 			// act
 			const result: IHtmlTemplateInfoResults = await sut.loadInlineTemplates([template]);
+
+			// assert
+			assert.deepEqual(result.htmlReferences, expectedResult);
+		});
+
+		it('then html references should be set for routes', async () => {
+			// arrange
+			const sut = new HtmlTemplateInfoCache();
+
+			const expectedResult = {
+				'inline-component': [{
+					col: 27,
+					line: 6,
+					relativeHtmlPath: 'path'
+				}]
+			};
+
+			const route: Route = new Route();
+
+			route.name = 'example_route';
+			route.pos = {
+				line: 4,
+				character: 13
+			};
+			route.path = 'path';
+			route.views = [];
+
+			const inlineComponent = new Route();
+			inlineComponent.name = 'inline-component';
+			inlineComponent.pos = {
+				line: 6,
+				character: 24
+			};
+			inlineComponent.path = 'path';
+			inlineComponent.template = {
+				path: 'path',
+				pos: {
+					line: 6,
+					character: 25
+				},
+				body: '<inline-component></inline-component>'
+			};
+			route.views.push(inlineComponent);
+
+			const routes = _.flatMap([route], (c) => {
+				if (c.template && c.template.body) {
+					return c.template;
+				}
+
+				if (c.views && c.views.length > 0) {
+					return c.views.filter(v => v.template && v.template.body).map(v => v.template);
+				}
+			});
+
+			// act
+			const result: IHtmlTemplateInfoResults = await sut.loadInlineTemplates(routes);
 
 			// assert
 			assert.deepEqual(result.htmlReferences, expectedResult);

--- a/test/utils/route.test.ts
+++ b/test/utils/route.test.ts
@@ -6,6 +6,19 @@ import { mockRoot } from '../../src/utils/vsc';
 
 describe('Given Route class', () => {
 	describe('when calling parse()', () => {
+		it('on route with views then templates are set correctly', async () => {
+			mockRoot('testRoot');
+			const sourceFile = getRouteSourceFile('route.views_template.ts');
+
+			const [route] = await Route.parse(sourceFile, []);
+
+			assert.equal(route.path, sourceFile.path);
+			assert.equal((route.views[0] as Route).template.body, '<inline-component></inline-component>');
+			assert.equal((route.views[1] as Route).template.body, 'inline-template');
+			assert.equal((route.views[2] as Route).template.path, path.normalize('testRoot/subdir/template.html'));
+			assert.equal((route.views[3] as Route).template.body, '<template-component></template-component>');
+		});
+
 		it('on route with inline template then template is set correctly', async () => {
 			const sourceFile = getRouteSourceFile('route.inline_template.ts');
 

--- a/test/utils/typescriptParser.test.ts
+++ b/test/utils/typescriptParser.test.ts
@@ -13,6 +13,15 @@ describe('Given TypescriptParser', () => {
 			should(result).be.undefined();
 		});
 
+		it('and variable is aliased as default then the variable declaration is returned', () => {
+			const sourceFile = getTestSourceFile(`const x = 'test'; export { x as default };`);
+			const parser = new TypescriptParser(sourceFile);
+
+			const result = parser.getExportedVariable('not_found');
+
+			should(result).be.undefined();
+		});
+
 		['var', 'let', 'const'].forEach(item => {
 			it(`and '${item}' is exported then variable declaration is returned`, () => {
 				const sourceFile = getTestSourceFile(`export ${item} variable = 'value';`);
@@ -30,6 +39,17 @@ describe('Given TypescriptParser', () => {
 				const parser = new TypescriptParser(sourceFile);
 
 				const result = parser.getExportedVariable('variable');
+
+				should(result).not.be.undefined();
+				should(result.getText()).be.equal(`variable = 'value'`);
+			});
+
+			it(`and '${item}' is exported via default export and no matching variable exists, then default is returned`, () => {
+				const sourceFile = getTestSourceFile(`${item} variable = 'value';
+													  export default variable;`);
+				const parser = new TypescriptParser(sourceFile);
+
+				const result = parser.getExportedVariable('nomatch');
 
 				should(result).not.be.undefined();
 				should(result.getText()).be.equal(`variable = 'value'`);


### PR DESCRIPTION
Addresses issue #28  …
Enhances handling of default exports
Added handling for all top-level ES module exports (there are others but they are less common for AngularJS)
Fixed a bug when parsing a component with ```bindings: true``` to isolate scope instead of actually providing a binding definition object
Added relevant tests